### PR TITLE
Fixes for duplicated words around <strong> tags

### DIFF
--- a/3-Moves.xml
+++ b/3-Moves.xml
@@ -34,7 +34,7 @@
 <li>Who’s really in control here?</li>
 <li>What here is not what it appears to be?</li></ul>
 <h2 aid:pstyle="BasicMoveName">Parley</h2>
-<p aid:pstyle="NoIndent">When you <strong>you have leverage on a GM character and manipulate them</strong>, roll+Cha. Leverage is something they need or want. On a hit they ask you for something and do it if you make them a promise first. On a 7–9, they need some concrete assurance of your promise, right now.</p>
+<p aid:pstyle="NoIndent">When you <strong>have leverage on a GM character and manipulate them</strong>, roll+Cha. Leverage is something they need or want. On a hit they ask you for something and do it if you make them a promise first. On a 7–9, they need some concrete assurance of your promise, right now.</p>
 <h2 aid:pstyle="BasicMoveName">Aid or Interfere</h2>
 <p aid:pstyle="NoIndent">When you <strong>help or hinder someone you have a Bond with</strong>, roll+Bond with them. On a 10+ they take +1 or -2, your choice. On a 7–9 you also expose yourself to danger, retribution, or cost.</p></Story>
 <h1>Special Moves</h1>
@@ -45,7 +45,7 @@
 <h2 aid:pstyle="BasicMoveName">Make Camp</h2>
 <p aid:pstyle="NoIndent">When you <strong>settle in to rest</strong> consume a ration. If you're somewhere dangerous decide the watch order as well. If you have enough XP you may Level Up. When you wake from at least a few uninterrupted hours of sleep heal damage equal to half your max HP.</p>
 <h2 aid:pstyle="BasicMoveName">Take Watch</h2>
-<p aid:pstyle="NoIndent">When you <strong>you're on watch and something approaches the camp</strong> roll+Wis. On a 10+ you're able to wake the camp and prepare a response, the camp takes +1 forward. On a 7–9 you react just a moment too late; the camp is awake but hasn't had time to prepare. You have weapons and armor but little else. On a miss whatever lurks outside the campfire's light has the drop on you.</p>
+<p aid:pstyle="NoIndent">When <strong>you're on watch and something approaches the camp</strong> roll+Wis. On a 10+ you're able to wake the camp and prepare a response, the camp takes +1 forward. On a 7–9 you react just a moment too late; the camp is awake but hasn't had time to prepare. You have weapons and armor but little else. On a miss whatever lurks outside the campfire's light has the drop on you.</p>
 <h2 aid:pstyle="BasicMoveName">Undertake a Perilous Journey</h2>
 <p aid:pstyle="NoIndent">When you travel through hostile territory, choose one member of the party to act as trailblazer, one to scout ahead, and one to be quartermaster (the same character cannot have two jobs). If you don't have enough party members or choose not to assign a job, treat that job as if it had rolled a 6. Each character with a job to do rolls+Wis. On a 10+ the quartermaster reduces the number of rations required by one. On a 10+ the trailblazer reduces the amount of time it takes to reach your destination (the GM will say by how much). On a 10+ the scout will spot any trouble quick enough to let you get the drop on it. On a 7–9 each roles performs their job as expected: the normal number of rations are consumed, the journey takes about as long as expected, no one gets the drop on you but you don't get the drop on them either.</p>
 <h2 aid:pstyle="BasicMoveName">Level Up</h2>

--- a/a1-Thanks.xml
+++ b/a1-Thanks.xml
@@ -4,5 +4,6 @@
 <h1>Contributors</h1>
 <p aid:pstyle="NoIndent">Tresi Arvizo</p>
 <p aid:pstyle="NoIndent">Jeremy Friesen</p>
+<p aid:pstyle="NoIndent">Nathan Black</p>
 <h1>Guild Members</h1>
 </Story></Root>


### PR DESCRIPTION
The word you or you're occurred before/after `<strong>` tags on lines 37 and 48.

Also added my name to Thanks, as per readme.
