### PR TITLE
Spell Will-o-wisp correctly.

### DIFF
--- a/text/monster_settings/Swamp.xml
+++ b/text/monster_settings/Swamp.xml
@@ -143,7 +143,7 @@
 <p aid:pstyle="MonsterDescription">Tall. Real tall. Eight or nine feet when they’re young or weak. Covered all over in warty, tough skin, too. Big teeth, stringy hair like swamp moss and long, dirty nails. Some are green, some grey, some black. They’re clannish and hateful of each other, not to mention all the rest of us. Near impossible to kill, too, unless you’ve fire or acid to spare—cut a limb off and watch. In a few days, you’ve got two trolls where you once had one. A real serious problem, as you can imagine. <em>Instinct</em>: To smash</p>
 <ul><li>Undo the effects of an attack (unless caused by a weakness, your call)</li>
 <li>Hurl something or someone</li></ul>
-<p aid:pstyle="MonsterName">Wll-o-wisp	<span aid:cstyle="Tags">Solitary, Tiny, Magical</span></p>
+<p aid:pstyle="MonsterName">Will-o-wisp	<span aid:cstyle="Tags">Solitary, Tiny, Magical</span></p>
 <p aid:pstyle="MonsterStats">Ray (w[2d8-2] damage)	12 HP	0 Armor</p>
 <p aid:pstyle="MonsterStats"><span aid:cstyle="Tags">Near</span></p>
 <p aid:pstyle="MonsterQualities"><strong>Special Qualities:</strong> Body of light</p>


### PR DESCRIPTION
Typo in creature name.
