### PR TITLE
Normalized equipment attribute order.

### DIFF
--- a/text/Cleric.xml
+++ b/text/Cleric.xml
@@ -63,7 +63,7 @@ Show the world who is lord.</p></div>
 <h3 aid:pstyle="MoveName">Evil</h3>
 <p aid:pstyle="NoIndent">Harm another to prove the superiority of your church or god.</p></div>
 <h2>Gear</h2>
-<div id="gear"><p aid:pstyle="NoIndent">Your Load is 4+Strength. You carry dungeon rations (1 weight, 5 uses) and some symbol of the divine, describe it (weight 0). Choose your defenses:</p>
+<div id="gear"><p aid:pstyle="NoIndent">Your Load is 4+Strength. You carry dungeon rations (5 uses, 1 weight) and some symbol of the divine, describe it (weight 0). Choose your defenses:</p>
 <ul><li aid:pstyle="Option">Chainmail (1 armor, 1 weight)</li>
 <li aid:pstyle="Option">Shield (+1 armor, 2 weight)</li></ul>
 <p aid:pstyle="NoIndent">Choose your armament:</p>

--- a/text/Fighter.xml
+++ b/text/Fighter.xml
@@ -77,7 +77,7 @@
 <h3 aid:pstyle="MoveName">Evil</h3>
 <p aid:pstyle="NoIndent">Kill a defenseless or surrendered enemy.</p></div>
 <h2>Gear</h2>
-<div id="gear"><p aid:pstyle="NoIndent">Your Load is 6+Strength. You carry your signature weapon and dungeon rations (1 weight, 5 uses). Choose your defenses:</p>
+<div id="gear"><p aid:pstyle="NoIndent">Your Load is 6+Strength. You carry your signature weapon and dungeon rations (5 uses, 1 weight). Choose your defenses:</p>
 <ul><li aid:pstyle="Option">Chainmail (1 armor, 1 weight) and adventuring gear (1 weight)</li>
 <li aid:pstyle="Option">Scale armor (2 armor, 3 weight)</li></ul>
 <p aid:pstyle="NoIndent">Choose two:</p>

--- a/text/First_Session.xml
+++ b/text/First_Session.xml
@@ -1,3 +1,4 @@
+
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Root xmlns:aid="http://ns.adobe.com/AdobeInDesign/4.0/">
 <h1>First Session</h1>

--- a/text/Paladin.xml
+++ b/text/Paladin.xml
@@ -61,7 +61,7 @@ So guide these fools, Paladin. Take up your holy cause and bring salvation to th
 <h3 aid:pstyle="MoveName">Good</h3>
 <p aid:pstyle="NoIndent">Endanger yourself to protect someone weaker than you.</p></div>
 <h2>Gear</h2>
-<div id="gear"><p aid:pstyle="NoIndent">Your Load is 6+Strength. You start with dungeon rations (1 weight, 5 uses), scale armor (2 armor, 3 weight), and some mark of faith, describe it (0 weight). Choose your weapon:</p>
+<div id="gear"><p aid:pstyle="NoIndent">Your Load is 6+Strength. You start with dungeon rations (5 uses, 1 weight), scale armor (2 armor, 3 weight), and some mark of faith, describe it (0 weight). Choose your weapon:</p>
 <ul><li aid:pstyle="Option">Halberd (Reach, +1 damage, two-handed, 2 weight)</li>
 <li aid:pstyle="Option">Long sword (Close, +1 damage, 1 weight) and shield (+1 armor, 2 weight)</li></ul>
 <p aid:pstyle="NoIndent">Choose one:</p>

--- a/text/Ranger.xml
+++ b/text/Ranger.xml
@@ -65,7 +65,7 @@
 <h3 aid:pstyle="MoveName">Neutral</h3>
 <p aid:pstyle="NoIndent">Help an animal or spirit of the wild.</p></div>
 <h2>Gear</h2>
-<div id="gear"><p aid:pstyle="NoIndent">Your Load is 4+Strength. You start with dungeon rations (1 weight, 5 uses), leather armor (1 armor, 1 weight), and a bundle or arrows (3 ammo, 2 weight). Choose your armament:</p>
+<div id="gear"><p aid:pstyle="NoIndent">Your Load is 4+Strength. You start with dungeon rations (5 uses, 1 weight), leather armor (1 armor, 1 weight), and a bundle or arrows (3 ammo, 2 weight). Choose your armament:</p>
 <ul><li aid:pstyle="Option">Hunter's bow (Near, Far, 1 weight) and short sword (Close, 1 weight)</li>
 <li aid:pstyle="Option">Hunter's bow (Near, Far, 1 weight) and spear (Reach, 1 weight)</li></ul>
 <p aid:pstyle="NoIndent">Choose one:</p>

--- a/text/Thief.xml
+++ b/text/Thief.xml
@@ -60,7 +60,7 @@
 <h3 aid:pstyle="MoveName">Evil</h3>
 <p aid:pstyle="NoIndent">Shift danger or blame from yourself to someone else.</p></div>
 <h2>Gear</h2>
-<div id="gear"><p aid:pstyle="NoIndent">Your Load is 2+Strength. You start with one dungeon rations (1 weight, 5 uses), leather armor (1 armor, 1 weight), 3 uses of your chosen poison, and 10 coin. Choose your arms:</p>
+<div id="gear"><p aid:pstyle="NoIndent">Your Load is 2+Strength. You start with one dungeon rations (5 uses, 1 weight), leather armor (1 armor, 1 weight), 3 uses of your chosen poison, and 10 coin. Choose your arms:</p>
 <ul><li aid:pstyle="Option">Dagger (Hand, 1 weight) and short sword (Close, 1 weight)</li>
 <li aid:pstyle="Option">Rapier (close, precise, 1 weight)</li></ul>
 <p aid:pstyle="NoIndent">Choose a ranged weapon:</p>

--- a/text/Wizard.xml
+++ b/text/Wizard.xml
@@ -60,7 +60,7 @@
 <h3 aid:pstyle="MoveName">Evil</h3>
 <p aid:pstyle="NoIndent">Use magic to cause terror and fear.</p></div>
 <h2>Gear</h2>
-<div id="gear"><p aid:pstyle="NoIndent">Your Load is equal to your Strength. You start with your spellbook (1 weight) and dungeon rations (1 weight, 5 uses). Choose your defenses:</p>
+<div id="gear"><p aid:pstyle="NoIndent">Your Load is equal to your Strength. You start with your spellbook (1 weight) and dungeon rations (5 uses, 1 weight). Choose your defenses:</p>
 <ul><li aid:pstyle="Option">Leather armor (1 armor, 1 weight)</li>
 <li aid:pstyle="Option">Bag of books (5 uses, 2 weight) and 3 healing potions</li></ul>
 <p aid:pstyle="NoIndent">Choose your weapon:</p>


### PR DESCRIPTION
In some cases equipment attributes were listed as (5 uses, 1 weight)
and in other cases they were listed as (1 weight, 5 uses). Moved
the uses to the first listed attribute and weight as the second
attribute.
