### PR TITLE
Added Spell Headers

### DIFF
--- a/text/Cleric_Spells.xml
+++ b/text/Cleric_Spells.xml
@@ -9,7 +9,8 @@
 <p aid:pstyle="NoIndent">Food or water you hold in your hands while you cast this spell is consecrated by your deity. In addition to now being holy or unholy, the affected substance is purified of any mundane spoilage.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Guidance</span>	Rote</p>
 <p aid:pstyle="NoIndent">The symbol of your deity appears before you and gestures towards the direction or course of action your deity would have you take then disappears. The message is through gesture only; your communication through this spell is severely limited.</p></div>
-<div><p aid:pstyle="SpellName" id="SpellName"><span aid:cstyle="SpellName">Bless</span>	Level 1	<em>Ongoing</em></p>
+<div><h2>Level 1 Spells</h2>
+<p aid:pstyle="SpellName" id="SpellName"><span aid:cstyle="SpellName">Bless</span>	Level 1	<em>Ongoing</em></p>
 <p aid:pstyle="NoIndent">Your deity smiles upon a combatant of your choice. They take +1 ongoing so long as battle continues and they stand and fight. While this spell is ongoing you take -1 to cast a spell.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Cure Light Wounds</span>	Level 1</p>
 <p aid:pstyle="NoIndent">At your touch wounds scab and bones cease to ache. Heal an ally you touch of 1d8 damage.</p>
@@ -23,7 +24,8 @@
 <p aid:pstyle="NoIndent">As you cast this spell, you walk the perimeter of an area, consecrating it to your deity. As long as you stay within that area you are alerted whenever someone acts with malice within the sanctuary (including entering with harmful intent). Anyone who receives healing within a sanctuary heals +1d4 HP.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Speak With Dead</span>	Level 1</p>
 <p aid:pstyle="NoIndent">A corpse converses with you briefly. It will answer any three questions you pose to it to the best of the knowledge it had in life and the knowledge it gained in death.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Animate Dead</span>	Level 3	<em>Ongoing</em></p>
+<div><h2>Level 3 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Animate Dead</span>	Level 3	<em>Ongoing</em></p>
 <p aid:pstyle="NoIndent">You invoke a hungry spirit to possess a recently-dead body and serve you. This creates a zombie that follows your orders to the best of its limited abilities. Treat the zombie as a character, but with access to only the basic moves. It has a +1 modifier for all stats and 1 HP. The zombie also gets your choice of 1d4 of these traits:</p>
 <ul><li>It’s talented. Give one stat a +2 modifier.</li>
 <li>It’s durable. It has +2 HP for each level you have.</li>
@@ -43,7 +45,8 @@
 <p aid:pstyle="NoIndent">The GM may, depending on the circumstances, allow you to resurrect the corpse now, with the understanding that the conditions must be met before it’s permanent, or require you to meet the conditions before the corpse is resurrected.</p> 
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Hold Person</span>	Level 3</p>
 <p aid:pstyle="NoIndent">Choose a person you can see. Until you cast a spell or leave their presence they cannot act except to speak. This effect ends immediately if the target takes damage from any source.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Revelation</span>	Level 5</p>
+<div><h2>Level 5 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Revelation</span>	Level 5</p>
 <p aid:pstyle="NoIndent">Your deity answers your prayers with a moment of perfect understanding. The GM will shed light on the current situation. When acting on the information, you take +1 forward.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Cure Critical Wounds</span>	Level 5</p>
 <p aid:pstyle="NoIndent">Heal an ally you touch of 3d8 damage.</p>
@@ -57,7 +60,8 @@
 <p aid:pstyle="NoIndent">Your vision is opened to the true nature of everything you lay your eyes on. You pierce illusions and see things that have been hidden. The GM will describe the area before you ignoring any illusions and falsehoods, magical or otherwise. While this spell is ongoing you take -1 to cast a spell.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Trap Soul</span>	Level 5</p>
 <p aid:pstyle="NoIndent">You trap the soul of a dying creature within a gem. The trapped creature is aware of its imprisonment but can still be manipulated through spells, parley, and other effects. All moves against the trapped creature are at +1. You can free the soul at any time but it can never be recaptured once freed.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Word of Recall</span>	Level 7</p>
+<div><h2>Level 7 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Word of Recall</span>	Level 7</p>
 <p aid:pstyle="NoIndent">Choose a word. The first time after casting this spell that you speak the chosen word, you and any allies touching you when you cast the spell are immediately returned to the exact spot where you cast the spell. You can only maintain a single location; casting Word of Recall again before speaking the word replaces the earlier spell.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Heal</span>	Level 7</p>
 <p aid:pstyle="NoIndent">Touch an ally and you may heal their damage a number of points up to your maximum HP.</p>
@@ -69,7 +73,8 @@
 <p aid:pstyle="NoIndent">Choose a creature whose true name you know. This spell creates permanent runes on a target surface that will kill that creature, should they read them.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Control Weather</span>	Level 7</p>
 <p aid:pstyle="NoIndent">Pray for rain—or sun, wind, or snow. Within a day or so, your god will answer. The weather will change according to your will and last a handful of days.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Storm of Vengeance</span>	Level 9</p>
+<div><h2>Level 9 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Storm of Vengeance</span>	Level 9</p>
 <p aid:pstyle="NoIndent">Your deity brings the unnatural weather of your choice to pass. Rain of blood or acid, clouds of souls, wind that can carry away buildings, or any other weather you can imagine: ask and it shall come.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Repair</span>	Level 9</p>
 <p aid:pstyle="NoIndent">Choose one event in the target’s past. All effects of that event, including damage, poison, disease, and magical effects, are ended and repaired. HP and diseases are healed, poisons are neutralized, magical effects are ended.</p>

--- a/text/Wizard_Spells.xml
+++ b/text/Wizard_Spells.xml
@@ -8,7 +8,8 @@
 <p aid:pstyle="NoIndent">You conjure a simple invisible construct that can do nothing but carry items. It has load 3 and carries anything you hand to it. It cannot pick up items on its own and can only carry those you give to it. Items carried by an unseen servant appear to float in the air a few paces behind you. An unseen servant that takes damage or leaves your presence is immediately dispelled, dropping any items it carried. Otherwise the unseen servant serves you until you end the spell.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Prestidigitation</span>	Cantrip</p>
 <p aid:pstyle="NoIndent">You perform minor tricks of true magic. If you touch an item as part of the casting you can make cosmetic changes to it: clean it, soil it, cool it, warm it, flavor it, or change its color. If you cast the spell without touching an item you can instead create minor illusions no bigger than yourself. Prestidigitation illusions are crude and clearly illusions—they won’t fool anyone, but they might entertain them.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Contact Spirits</span>	Level 1	<em>Summoning</em></p>
+<div><h2>Level 1 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Contact Spirits</span>	Level 1	<em>Summoning</em></p>
 <p aid:pstyle="NoIndent">Name the spirit you wish to contact (or leave it to the GM). You pull that creature through the planes, just close enough to speak to you. It is bound to answer any one question you ask to the best of its ability.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Detect Magic</span>	Level 1	<em>Divination</em></p>
 <p aid:pstyle="NoIndent">One of your senses is briefly attuned to magic. The GM will tell you what here is magical.</p>
@@ -22,11 +23,12 @@
 <p aid:pstyle="NoIndent">Projectiles of pure magic spring from your fingers. Deal 2d4 damage to one target.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Alarm</span>	Level 1</p>
 <p aid:pstyle="NoIndent">Walk a wide circle as you cast this spell. Until you prepare spells again your magic will alert you if a creature crosses that circle. Even if you are asleep, the spell will shake you from your slumber.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Dispel Magic</span>	Level 3</p>
+<div><h2>Level 3 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Dispel Magic</span>	Level 3</p>
 <p aid:pstyle="NoIndent">Choose a spell or magic effect in your presence: this spell rips it apart. Lesser spells are ended, powerful magic is just reduced or dampened so long as you are nearby.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Visions Through Time</span>	Level 3	<em>Divination</em></p>
 <p aid:pstyle="NoIndent">Cast this spell and gaze into a reflective surface to see into the depths of time. The GM will reveal the details of a grim portent to you—a bleak event that will come to pass without your intervention. They’ll tell you something useful about how you can interfere with the grim portent’s dark outcomes. Rare is the portent that claims “You’ll live happily ever after.” Sorry.</p>
-<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Fireball</span>	Level 3	Evocation</p>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Fireball</span>	Level 3	<em>Evocation</em></p>
 <p aid:pstyle="NoIndent">You evoke a mighty ball of flame that envelops your target and everyone nearby, inflicting 2d6 damage which ignores armor.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Mimic</span>	Level 3	<em>Ongoing</em></p>
 <p aid:pstyle="NoIndent">You take the form of someone you touch while casting this spell. Your physical characteristics match theirs exactly but your behavior may not. This change persists until you take damage or choose to return to your own form. While this spell is ongoing you lose access to all your wizard moves.</p>
@@ -34,7 +36,8 @@
 <p aid:pstyle="NoIndent">You create an illusory image of yourself. When you are attacked, roll a d6. On a 4, 5, or 6 the attack hits the illusion instead, the image then dissipates and the spell ends.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Sleep</span>	Level 3	<em>Enchantment</em></p>
 <p aid:pstyle="NoIndent">1d4 enemies you can see of the GM’s choice fall asleep. Only creatures capable of sleeping are affected. They awake as normal: loud noises, jolts, pain.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Cage</span>	Level 5	<em>Evocation Ongoing</em></p>
+<div><h2>Level 5 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Cage</span>	Level 5	<em>Evocation Ongoing</em></p>
 <p aid:pstyle="NoIndent">The target is held in a cage of magical force. Nothing can get in or out of the cage. The cage remains until you cast another spell or dismiss it. While the spell is ongoing, the caged creature can hear your thoughts and you cannot leave sight of the cage.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Contact Other Plane</span>	Level 5	<em>Divination</em></p>
 <p aid:pstyle="NoIndent">You send a request to another plane. Specify who or what you’d like to contact by location, type of creature, name, or title. You open a two-way communication with that creature. Your communication can be cut off at any time by you or the creature you contacted.</p>
@@ -51,7 +54,8 @@
 <li>Its bond to your plane is strong: +2 HP for each level you have</li>
 <li>It has some useful adaptation</li></ul>
 <p aid:pstyle="NoIndent">The GM will tell you the type of monster you get based on the traits you select. The creature remains on this plane until it dies or you dismiss it. While the spell is ongoing you take -1 to cast a spell.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Dominate</span>	Level 7	<em>Enchantment Ongoing</em></p>
+<div><h2>Level 7 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Dominate</span>	Level 7	<em>Enchantment Ongoing</em></p>
 <p aid:pstyle="NoIndent">Your touch pushes your mind into someone else’s. You gain 1d4 hold. Spend one hold to make the target take one of these actions:</p>
 <ul><li>Speak a few words of your choice</li>
 <li>Give you something they hold</li>
@@ -66,7 +70,8 @@
 <p aid:pstyle="NoIndent">Choose a 5th level or lower spell you know. Describe a trigger condition using a number of words equal to your level. The chosen spell is held until you choose to unleash it or the trigger condition is met, whichever happens first. You don’t have to roll for the held spell, it just takes effect. You may only have a single contingent spell held at a time; if you cast Contingency while you have a held spell, the new held spell replaces the old one.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Cloudkill</span>	Level 7	<em>Summoning Ongoing</em></p>
 <p aid:pstyle="NoIndent">A cloud of fog drifts into this realm from beyond the Black Gates of Death, filling the immediate area. Whenever a creature in the area takes damage it takes an additional, separate 1d6 damage which ignores armor. This spell persists so long as you can see the affected area, or until you dismiss it.</p></div>
-<div><p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Antipathy</span>	Level 9	<em>Enchantment Ongoing</em></p>
+<div><h2>Level 9 Spells</h2>
+<p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Antipathy</span>	Level 9	<em>Enchantment Ongoing</em></p>
 <p aid:pstyle="NoIndent">Choose a target and describe a type of creature or an alignment. Creatures of the specified type or alignment cannot come within sight of the target. If a creature of the specified type does find itself within sight of the target, it immediately flees. This effect continues until you leave the target’s presence or you dismiss the spell. While the spell is ongoing you take -1 to cast a spell.</p>
 <p aid:pstyle="SpellName"><span aid:cstyle="SpellName">Alert</span>	Level 9	<em>Divination</em></p>
 <p aid:pstyle="NoIndent">Describe an event. The GM will tell you when that event occurs, no matter where you are or how far away the event is. If you choose, you can view the location of the event as though you were there in person. You can only have one Alert active at a time.</p>


### PR DESCRIPTION
The Cantrips and Rotes have a header, but the spells do not so I added
them. Also, fireball's evocation type was not italicized so I corrected
that as well.
